### PR TITLE
fix: After clearing, the node should also be restored to a leaf node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/target/
+*/target/
+*/*/target/
+*/*/*/target/
+*/*/*/*/target/
+*/*/*/*/*/target/
+*/*/*/*/*/*/target/
+*/*/*/*/*/*/*/target/
+*/*/*/*/*/*/*/*/target/
+*/*/*/*/*/*/*/*/*/target/
+
+Cargo.lock
+
+**/*.rs.bk
+.idea

--- a/src/collections/btree_map/mod.rs
+++ b/src/collections/btree_map/mod.rs
@@ -152,6 +152,7 @@ impl<K, V, A: Tuning> BTreeMap<K, V, A> {
     pub fn clear(&mut self) {
         self.len = 0;
         self.tree.dealloc(&self.atune);
+        self.tree = Tree::new();
     }
 
     /// Get number of key-value pairs in the map.


### PR DESCRIPTION
When BTreeMap is empty, it corresponds to a leaf node, so when BTreeMap calls clear, the node should also be restored to a leaf node.