### PR TITLE
Enhanced compatibility with `std`

### DIFF
--- a/src/collections/btree_map/mod.rs
+++ b/src/collections/btree_map/mod.rs
@@ -1555,10 +1555,18 @@ where
 // Mutable reference iteration.
 
 /// Iterator returned by [`BTreeMap::iter_mut`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct IterMut<'a, K, V> {
     len: usize,
     inner: RangeMut<'a, K, V>,
+}
+impl<K, V> Default for IterMut<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            len: Default::default(),
+            inner: Default::default(),
+        }
+    }
 }
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
@@ -1599,7 +1607,7 @@ struct StkMut<'a, K, V> {
 }
 
 /// Iterator returned by [`BTreeMap::range_mut`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RangeMut<'a, K, V> {
     /* There are two iterations going on to implement DoubleEndedIterator.
        fwd_leaf and fwd_stk are initially used for forward (next) iteration,
@@ -1778,6 +1786,16 @@ impl<'a, K, V> RangeMut<'a, K, V> {
                 return Some(x);
             }
             return None;
+        }
+    }
+}
+impl<K, V> Default for RangeMut<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            fwd_leaf: Default::default(),
+            bck_leaf: Default::default(),
+            fwd_stk: Default::default(),
+            bck_stk: Default::default(),
         }
     }
 }
@@ -1980,10 +1998,26 @@ impl<K, V, A: Tuning> IntoIterInner<K, V, A> {
 // Immutable reference iteration.
 
 /// Iterator returned by [`BTreeMap::iter`].
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 pub struct Iter<'a, K, V> {
     len: usize,
     inner: Range<'a, K, V>,
+}
+impl<K, V> Clone for Iter<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            len: self.len,
+            inner: self.inner.clone(),
+        }
+    }
+}
+impl<K, V> Default for Iter<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            len: Default::default(),
+            inner: Default::default(),
+        }
+    }
 }
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
@@ -2017,14 +2051,22 @@ impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
 impl<'a, K, V> FusedIterator for Iter<'a, K, V> {}
 
 /// Stack element for [`Range`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct Stk<'a, K, V> {
     v: IterPairVec<'a, K, V>,
     c: std::slice::Iter<'a, Tree<K, V>>,
 }
+impl<K, V> Clone for Stk<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            v: self.v.clone(),
+            c: self.c.clone(),
+        }
+    }
+}
 
 /// Iterator returned by [`BTreeMap::range`].
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 pub struct Range<'a, K, V> {
     fwd_leaf: IterPairVec<'a, K, V>,
     bck_leaf: IterPairVec<'a, K, V>,
@@ -2202,6 +2244,26 @@ impl<'a, K, V> Range<'a, K, V> {
         }
     }
 }
+impl<K, V> Clone for Range<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            fwd_leaf: self.fwd_leaf.clone(),
+            bck_leaf: self.bck_leaf.clone(),
+            fwd_stk: self.fwd_stk.clone(),
+            bck_stk: self.bck_stk.clone(),
+        }
+    }
+}
+impl<K, V> Default for Range<'_, K, V> {
+    fn default() -> Self {
+        Self {
+            fwd_leaf: Default::default(),
+            bck_leaf: Default::default(),
+            fwd_stk: Default::default(),
+            bck_stk: Default::default(),
+        }
+    }
+}
 impl<'a, K, V> Iterator for Range<'a, K, V> {
     type Item = (&'a K, &'a V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -2291,8 +2353,18 @@ impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
 impl<'a, K, V> FusedIterator for ValuesMut<'a, K, V> {}
 
 /// Iterator returned by [`BTreeMap::values`].
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 pub struct Values<'a, K, V>(Iter<'a, K, V>);
+impl<K, V> Clone for Values<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<K, V> Default for Values<'_, K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
     fn next(&mut self) -> Option<Self::Item> {
@@ -2312,8 +2384,18 @@ impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
 impl<'a, K, V> FusedIterator for Values<'a, K, V> {}
 
 /// Iterator returned by [`BTreeMap::keys`].
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 pub struct Keys<'a, K, V>(Iter<'a, K, V>);
+impl<K, V> Clone for Keys<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<K, V> Default for Keys<'_, K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
     fn next(&mut self) -> Option<Self::Item> {
@@ -2875,7 +2957,7 @@ impl<'a, K, V, A: Tuning> CursorMutKey<'a, K, V, A> {
 }
 
 /// Cursor returned by [`BTreeMap::lower_bound`], [`BTreeMap::upper_bound`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Cursor<'a, K, V, A: Tuning = DefaultTuning> {
     leaf: *const Leaf<K, V>,
     index: usize,
@@ -2885,6 +2967,17 @@ pub struct Cursor<'a, K, V, A: Tuning = DefaultTuning> {
 
 unsafe impl<'a, K: Send, V: Send, A: Tuning + Send> Send for Cursor<'a, K, V, A> {}
 unsafe impl<'a, K: Sync, V: Sync, A: Tuning + Sync> Sync for Cursor<'a, K, V, A> {}
+
+impl<K, V, A: Tuning> Clone for Cursor<'_, K, V, A> {
+    fn clone(&self) -> Self {
+        Self {
+            leaf: self.leaf,
+            index: self.index,
+            stack: self.stack.clone(),
+            _pd: self._pd,
+        }
+    }
+}
 
 impl<'a, K, V, A: Tuning> Cursor<'a, K, V, A> {
     fn lower_bound<Q>(bt: &'a BTreeMap<K, V, A>, bound: Bound<&Q>) -> Self

--- a/src/collections/btree_map/mod.rs
+++ b/src/collections/btree_map/mod.rs
@@ -1389,6 +1389,19 @@ pub enum Entry<'a, K, V, A: Tuning = DefaultTuning> {
     /// Occupied entry - map already contains key.
     Occupied(OccupiedEntry<'a, K, V, A>),
 }
+impl<K, V, A> Debug for Entry<'_, K, V, A>
+where
+    K: Debug + Ord,
+    V: Debug,
+    A: Tuning,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vacant(x) => f.debug_tuple("Vacant").field(x).finish(),
+            Self::Occupied(x) => f.debug_tuple("Occupied").field(x).finish(),
+        }
+    }
+}
 impl<'a, K, V, A: Tuning> Entry<'a, K, V, A>
 where
     K: Ord,
@@ -1821,6 +1834,7 @@ impl<'a, K, V> FusedIterator for RangeMut<'a, K, V> {}
 // Consuming iteration.
 
 /// Consuming iterator for [`BTreeMap`].
+#[derive(Debug)]
 pub struct IntoIter<K, V, A: Tuning = DefaultTuning> {
     len: usize,
     inner: IntoIterInner<K, V, A>,
@@ -1869,12 +1883,14 @@ impl<K, V, A: Tuning> ExactSizeIterator for IntoIter<K, V, A> {
 impl<K, V, A: Tuning> FusedIterator for IntoIter<K, V, A> {}
 
 /// Stack element for [`IntoIterInner`].
+#[derive(Debug)]
 struct StkCon<K, V> {
     v: IntoIterPairVec<K, V>,
     c: IntoIterShortVec<Tree<K, V>>,
 }
 
 /// For implementation of [`IntoIter`].
+#[derive(Debug)]
 struct IntoIterInner<K, V, A: Tuning = DefaultTuning> {
     fwd_leaf: IntoIterPairVec<K, V>,
     bck_leaf: IntoIterPairVec<K, V>,
@@ -2289,6 +2305,7 @@ impl<'a, K, V> DoubleEndedIterator for Range<'a, K, V> {
 impl<'a, K, V> FusedIterator for Range<'a, K, V> {}
 
 /// Consuming iterator returned by [`BTreeMap::into_keys`].
+#[derive(Debug)]
 pub struct IntoKeys<K, V, A: Tuning = DefaultTuning>(IntoIter<K, V, A>);
 impl<K, V> Default for IntoKeys<K, V> {
     fn default() -> Self {
@@ -2317,6 +2334,7 @@ impl<K, V, A: Tuning> ExactSizeIterator for IntoKeys<K, V, A> {
 impl<K, V, A: Tuning> FusedIterator for IntoKeys<K, V, A> {}
 
 /// Consuming iterator returned by [`BTreeMap::into_values`].
+#[derive(Debug)]
 pub struct IntoValues<K, V, A: Tuning = DefaultTuning>(IntoIter<K, V, A>);
 impl<K, V> Default for IntoValues<K, V> {
     fn default() -> Self {
@@ -2488,6 +2506,7 @@ impl fmt::Display for UnorderedKeyError {
 impl std::error::Error for UnorderedKeyError {}
 
 /// Cursor that allows mutation of map, returned by [`BTreeMap::lower_bound_mut`], [`BTreeMap::upper_bound_mut`].
+#[derive(Debug)]
 pub struct CursorMut<'a, K, V, A: Tuning = DefaultTuning>(CursorMutKey<'a, K, V, A>);
 impl<'a, K, V, A: Tuning> CursorMut<'a, K, V, A> {
     fn lower_bound<Q>(map: &'a mut BTreeMap<K, V, A>, bound: Bound<&Q>) -> Self
@@ -2588,6 +2607,7 @@ impl<'a, K, V, A: Tuning> CursorMut<'a, K, V, A> {
 }
 
 /// Cursor that allows mutation of map keys, returned by [`CursorMut::with_mutable_key`].
+#[derive(Debug)]
 pub struct CursorMutKey<'a, K, V, A: Tuning = DefaultTuning> {
     map: *mut BTreeMap<K, V, A>,
     leaf: *mut Leaf<K, V>,

--- a/src/collections/btree_map/mod.rs
+++ b/src/collections/btree_map/mod.rs
@@ -1838,6 +1838,11 @@ impl<K, V, A: Tuning> IntoIter<K, V, A> {
         s
     }
 }
+impl<K, V> Default for IntoIter<K, V> {
+    fn default() -> Self {
+        BTreeMap::new().into_iter()
+    }
+}
 impl<K, V, A: Tuning> Iterator for IntoIter<K, V, A> {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -2285,6 +2290,11 @@ impl<'a, K, V> FusedIterator for Range<'a, K, V> {}
 
 /// Consuming iterator returned by [`BTreeMap::into_keys`].
 pub struct IntoKeys<K, V, A: Tuning = DefaultTuning>(IntoIter<K, V, A>);
+impl<K, V> Default for IntoKeys<K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 impl<K, V, A: Tuning> Iterator for IntoKeys<K, V, A> {
     type Item = K;
     fn next(&mut self) -> Option<Self::Item> {
@@ -2308,6 +2318,11 @@ impl<K, V, A: Tuning> FusedIterator for IntoKeys<K, V, A> {}
 
 /// Consuming iterator returned by [`BTreeMap::into_values`].
 pub struct IntoValues<K, V, A: Tuning = DefaultTuning>(IntoIter<K, V, A>);
+impl<K, V> Default for IntoValues<K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 impl<K, V, A: Tuning> Iterator for IntoValues<K, V, A> {
     type Item = V;
     fn next(&mut self) -> Option<Self::Item> {
@@ -2334,6 +2349,11 @@ impl<K, V, A: Tuning> FusedIterator for IntoValues<K, V, A> {}
 /// Iterator returned by [`BTreeMap::values_mut`].
 #[derive(Debug)]
 pub struct ValuesMut<'a, K, V>(IterMut<'a, K, V>);
+impl<K, V> Default for ValuesMut<'_, K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/collections/btree_map/vecs.rs
+++ b/src/collections/btree_map/vecs.rs
@@ -750,11 +750,20 @@ where
 }
 
 /// Non-mutable iterator for [`PairVec`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct IterPairVec<'a, K, V> {
     v: Option<&'a PairVec<K, V>>,
     ix: usize,
     ixb: usize,
+}
+impl<K, V> Clone for IterPairVec<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            v: self.v,
+            ix: self.ix,
+            ixb: self.ixb,
+        }
+    }
 }
 impl<'a, K, V> Default for IterPairVec<'a, K, V> {
     fn default() -> Self {

--- a/src/collections/btree_map/vecs.rs
+++ b/src/collections/btree_map/vecs.rs
@@ -250,6 +250,7 @@ where
 }
 
 /// Consuming iterator for [`ShortVec`].
+#[derive(Debug)]
 pub struct IntoIterShortVec<T> {
     start: usize,
     v: ShortVec<T>,


### PR DESCRIPTION
_I am not good at English. Sorry if there are any funny expressions._

----
The following two points have been improved.
- Add `Clone`, `Debug`, `Default` for some types.
- Relax implementations bound about `Clone`, `Default` 

NOTE: `derive` attribute assumes bounds on type parameters (ex; `#[derive(Clone)] struct SomeType<T>` produces `impl<T: Clone> Clone for SomeType<T>`, not `impl<T> Clone for SomeType<T>`. )
